### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Elcapitanoe/File-Hasher/security/code-scanning/11](https://github.com/Elcapitanoe/File-Hasher/security/code-scanning/11)

To fix the issue, we will add an explicit `permissions` block to the workflow, defining the minimal required permissions for the tasks performed in the job. Based on the workflow's operations (e.g., checking out code, installing dependencies, running builds, uploading artifacts), the job likely only needs read access to the repository contents (`contents: read`) and write permissions for uploading build artifacts (`actions: write`). These permissions should be added at the root level of the workflow so they apply to all jobs in the file, unless a specific job overrides them.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
